### PR TITLE
merge (#34)

### DIFF
--- a/public/examples/layouts/4.html
+++ b/public/examples/layouts/4.html
@@ -1,10 +1,10 @@
-<v-app id="example-4" left-fixed-sidebar sidebar-under-toolbar left-fixed-sidebar>
+<v-app id="example-4" left-fixed-sidebar sidebar-under-toolbar>
   <v-toolbar>
     <v-toolbar-side-icon @click.native.stop="nav4 = !nav4" class="hidden-sm-and-up"/>
     <v-toolbar-title>Toolbar</v-toolbar-title>
   </v-toolbar>
   <main>
-    <v-sidebar v-model="nav4" class="mt-0 scroll-y" :mobileBreakPoint="576">
+    <v-sidebar v-model="nav4" class="mt-0 scroll-y" :mobileBreakPoint="576" fixed>
       <v-list>
         <v-list-item v-for="i in 8" :key="i">
           <v-list-tile>

--- a/public/examples/pickers/2.html
+++ b/public/examples/pickers/2.html
@@ -2,11 +2,12 @@
   <v-row>
     <v-col md12 lg4>
       <div class="subheading text-xs-center">Portrait</div>
-      <v-date-picker v-model="e2" dark></v-date-picker>
+      <v-date-picker v-model="e2" actions dark></v-date-picker>
     </v-col>
     <v-col md12 lg8>
       <div class="subheading text-xs-center">Landscape</div>
-      <v-date-picker v-model="e2" landscape dark></v-date-picker>
+      <v-date-picker v-model="e2" actions landscape dark></v-date-picker>
+      <v-date-picker v-model="e2" dark></v-date-picker>
     </v-col>
   </v-row>
 </v-container>

--- a/public/examples/pickers/7.html
+++ b/public/examples/pickers/7.html
@@ -3,6 +3,5 @@
     <v-col md12 lg4 lg-offset8>
       <v-time-picker v-model="e7" format="24hr"></v-time-picker>
     </v-col>
-    </v-col>
   </v-row>
 </v-container>

--- a/public/examples/tabs/2.html
+++ b/public/examples/tabs/2.html
@@ -1,4 +1,4 @@
-<v-tabs id="mobile-tabs-2" grtabow>
+<v-tabs id="mobile-tabs-2" grow>
   <v-card class="primary white--text">
     <div>
       <v-card-row>


### PR DESCRIPTION
* Dev (#26)

* doc updates for new select

* tweaks after merge

* Polishing (#15)

* Polishing API descriptions and cleanup

* update List 'avatar' prop description

* added key to example

* updated docs

* updates

* removed route

* updated grid docs

* updated views, deps and config

* updated views

* updated nav

* created motion docs

* added keys for v-for

* removed depth

* updated select docs

* updates

* update for #255

* Enhancement/flexbox (#16)

* initial layout restructure based on flexbox

* offset example of grid

* add order and offset example

* add html to layout page

* add some info about scroll-y class to the layout section

* some more examples

* more examples for grid

* added wrap of child elements to grid

* added default styling flexbox behavour on v-app and v-content

* minor change on 3rd example of grids

* edit layout examples for the recent changes

* fixed minor css on column layout

* work on all v-row convert them to v-layout

* remove v-row from spec

* fixed height issue in grid example

* add sidebar below toolbar example

* minor changes for flexbox

* remove fixed attribute for sidebar

* updates for https://github.com/vuetifyjs/vuetify/issues/261

* it has been a long day

* doc cleanup for mobile

* reverted gridview

* updated scaling display changes

* replacing legacy z-depths (#18)

* replacing legacy z-depths

* Replace legacy z-depth classes

* dropping 'dp' from css classes

* adding elevation docs

* Feature/datatables (#21)

* init datatables docs

* updates

* updated datatable docs

* updated datatables docs

* updated data table docs

* updated view

* updates

* doc updates

* updated docs

* doc updates

* updates to docs

* doc updats

* removed need to declare tr/active state

* updated doc

* doc updates

* example for tooblar search (#22)

* moving helpers into layout section (#23)

* doc updates

* doc updates

* updated elevations, other tweaks

* updated data tables view

* adding all display helper classes (#24)

* added new card example

* doc updates

* fixed bug with data table items

* added lazy props

* Tweaks for 0.10 (#25)

* tweaks to Cards api & adding action symbols to updated docs

* adding component events to api

* adding types and descriptions to event api

* updating focus event

* enabling grid-offset examples (#281) and added "xl" breakpoint

* remove unnecessary text from offset

* doc updates

* updated docs

* updated docs

* [build]

* [build]

* [build]

* [build\
]

* improved data tables docs, updated for bug fix

* [build]

* [build]

* update for https://github.com/vuetifyjs/vuetify/issues/326

* Complete Path (#27)

* doc update for https://github.com/vuetifyjs/vuetify/issues/323

* updated docs

* [build]

* updated docs for bug fix https://github.com/vuetifyjs/vuetify/issues/340

* Feature/pickers (#31)

* init commit for pickers

* updated picker docs

* updated docs

* doc update

* added date picker docs

* updated pickers docs

* updated docs

* removed extra padding

* added docs

* updated docs

* updated docs

* Fixing errors in example layout 4 (#29)

- left-fixed-sidebar included twice
- v-sidebar needs fixed prop

* fix prop name