### PR TITLE
Remove secondary ripple parameter

### DIFF
--- a/pages/ListsView.vue
+++ b/pages/ListsView.vue
@@ -64,12 +64,6 @@
                   'Boolean',
                   'False',
                   'Used to set minimum tile height on a single-line list item'
-                ],
-                [
-                  'ripple',
-                  'Boolean',
-                  'False',
-                  'Designates whether the list tiles will attach the ripple directive'
                 ]
               ],
               model: {


### PR DESCRIPTION
Ripple is already listed in the router include. https://github.com/vuetifyjs/docs/blob/dev/components/ComponentParameters.vue#L207