### PR TITLE
Remove duplicate documentation entry

### DIFF
--- a/pages/ListsView.vue
+++ b/pages/ListsView.vue
@@ -64,12 +64,6 @@
                   'Boolean',
                   'False',
                   'Used to set minimum tile height on a single-line list item'
-                ],
-                [
-                  'ripple',
-                  'Boolean',
-                  'False',
-                  'Designates whether the list tiles will attach the ripple directive'
                 ]
               ],
               model: {


### PR DESCRIPTION
The `ripple` option on the `v-list-tile` documentation is duplicated

[doc](https://vuetifyjs.com/components/lists)
[screenshot](http://imgur.com/RTxz8MU)