### PR TITLE
Correct documentation of props for 'completed'

### DIFF
--- a/pages/SteppersView.vue
+++ b/pages/SteppersView.vue
@@ -56,10 +56,10 @@
             'v-stepper-step': {
               params: [
                 [
-                  'completed',
+                  'complete',
                   'Boolean',
                   'False',
-                  'Marks step as completed',
+                  'Marks step as complete',
                 ],
                 [
                   'complete-icon',


### PR DESCRIPTION
Corrected prop 'completed' to 'complete' in documentation to match docs to actual setup