### PR TITLE
Add prop to allow configuration of which keys execute a toggle

### DIFF
--- a/components/ComponentParameters.vue
+++ b/components/ComponentParameters.vue
@@ -320,6 +320,12 @@
             'Boolean',
             'False',
             'Hides hint, validation errors'
+          ],
+          [
+            'toggle-keys',
+            'Array',
+            '[13, 32]',
+            "Array of key codes that will toggle the input (if it supports toggling)"
           ]
         ]
       },


### PR DESCRIPTION
Doc change for: https://github.com/vuetifyjs/vuetify/pull/1289

It felt kind of weird to document it generically as an input prop but that matches the current implementation so it made the most sense to have it there.