### PR TITLE
Fixed IE10 support icon color

### DIFF
--- a/pages/QuickStartView.vue
+++ b/pages/QuickStartView.vue
@@ -159,7 +159,7 @@
                 v-icon(dark).primary fa-{{ browser.icon }}
               v-list-tile-content
                 v-list-tile-title {{ browser.title }}
-                v-list-tile-sub-title {{ browser.supported }}
+                v-list-tile-sub-title {{ browser.supported === true ? 'Supported' : (browser.supported === false ? 'Not supported' : browser.supported) }}
               v-list-tile-action
                 v-icon(v-if="!browser.supported").error--text clear
                 v-icon(v-else).success--text check
@@ -195,12 +195,12 @@
     data () {
       return {
         browsers: [
-          { icon: 'internet-explorer', title: 'IE9 / IE10', supported: 'Not Supported' },
+          { icon: 'internet-explorer', title: 'IE9 / IE10', supported: false },
           { icon: 'internet-explorer', title: 'IE11', supported: 'Supported w/ polyfill' },
-          { icon: 'edge', title: 'Edge', supported: 'Supported' },
-          { icon: 'chrome', title: 'Chrome', supported: 'Supported' },
-          { icon: 'firefox', title: 'Firefox', supported: 'Supported' },
-          { icon: 'safari', title: 'Safari 9+', supported: 'Supported' },
+          { icon: 'edge', title: 'Edge', supported: true },
+          { icon: 'chrome', title: 'Chrome', supported: true },
+          { icon: 'firefox', title: 'Firefox', supported: true },
+          { icon: 'safari', title: 'Safari 9+', supported: true },
         ],
         copied: false,
         copyTimeout: null,


### PR DESCRIPTION
IE10 support icon is green check, should be red cross

https://vuetifyjs.com/vuetify/quick-start
