### PR TITLE
Update ComponentParameters.vue

### DIFF
--- a/components/ComponentParameters.vue
+++ b/components/ComponentParameters.vue
@@ -110,7 +110,7 @@
             'scrollable',
             'Boolean',
             'False',
-            'When set to true, expects a card, card-title, card-text and card-actions. Will set card-text to overflow-y'
+            'When set to true, expects a card, card-title, card-text and card-actions. Additionally card-text should have specified height. Will set card-text to overflow-y'
           ],
           [
             'disabled',


### PR DESCRIPTION
'height' set to v-card-text in scrollable dialog/bottom-sheet is easly missable and confuses users, it should be clearly stated that its height need to be specified