### PR TITLE
Document the 'submit' event & add hint how to disable form submission

### DIFF
--- a/pages/FormsView.vue
+++ b/pages/FormsView.vue
@@ -48,7 +48,8 @@
           events: {
             'v-form': {
               params: [
-                ['input', 'Boolean', 'Validation state changed']
+                ['input', 'Boolean', 'Validation state changed'],
+                ['submit', '-', 'Form has been submitted. You can use <code>@submit.prevent</code> to suppress this event and disable form submission (e.g. to avoid reloading the page)']
               ]
             },
           }


### PR DESCRIPTION
I don't want my `v-form` to reload the page on submission and it seems that adding `@submit.prevent` does exactly what it says in that case. I know it's not vuetify specific, but it would anyway make sense to know that there is a `submit` event I can handle.

### Components > VForm > API > Events
![image](https://user-images.githubusercontent.com/6052590/30483054-bc6f0eae-9a25-11e7-8540-77dbbc1acb06.png)
