### PR TITLE
Fix double ripple on expansion panel example

### DIFF
--- a/examples/ripples/expansion-panels.vue
+++ b/examples/ripples/expansion-panels.vue
@@ -2,7 +2,7 @@
   <v-expansion-panel>
     <v-expansion-panel-content v-for="item in 5" :key="item" ripple>
       <div slot="header">
-        <div v-ripple="{ class: 'grey--text' }">Item</div>
+        <div>Item</div>
       </div>
       <v-card>
         <v-card-text class="grey lighten-3">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</v-card-text>


### PR DESCRIPTION
When clicking exactly on the header's text. The ripple prop is already in v-expansion-panel-content.