### PR TITLE
cross-env for windows friendly scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2135,9 +2135,9 @@
       }
     },
     "cross-env": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.0.5.tgz",
-      "integrity": "sha1-Q4PTZNlmCHPdGFs5ivO/717//vM=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.1.tgz",
+      "integrity": "sha512-Wtvr+z0Z06KO1JxjfRRsPC+df7biIOiuV4iZ73cThjFGkH+ULBZq1MkBdywEcJC4cTDbO6c8IjgRjfswx3YTBA==",
       "requires": {
         "cross-spawn": "5.1.0",
         "is-windows": "1.0.1"
@@ -2796,21 +2796,15 @@
       }
     },
     "event-source-polyfill": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-0.0.9.tgz",
-      "integrity": "sha1-GMYgXRcKsJ24if/OqjPw5JPxSlA=",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-0.0.11.tgz",
+      "integrity": "sha1-RXdpZqUERmMWrUc4SMYq9L11Gtg=",
       "dev": true
     },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "dev": true
-    },
-    "eventsource-polyfill": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/eventsource-polyfill/-/eventsource-polyfill-0.9.6.tgz",
-      "integrity": "sha1-EODRh/ERsWfyj9q5GIQ859gY8Tw=",
       "dev": true
     },
     "evp_bytestokey": {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "version": "0.0.5",
   "scripts": {
     "dev": "node server",
-    "start": "NODE_ENV=production node server",
+    "start": "cross-env NODE_ENV=production node server",
     "build": "rimraf public && npm run build:client && npm run build:server",
-    "archive": "NODE_ENV=production webpack --config archive/archive.config.js --progress --hide-modules",
-    "build:client": "NODE_ENV=production webpack --config build/webpack.client.config.js --progress --hide-modules",
-    "build:server": "NODE_ENV=production webpack --config build/webpack.server.config.js --progress --hide-modules"
+    "archive": "cross-env NODE_ENV=production webpack --config archive/archive.config.js --progress --hide-modules",
+    "build:client": "cross-env NODE_ENV=production webpack --config build/webpack.client.config.js --progress --hide-modules",
+    "build:server": "cross-env NODE_ENV=production webpack --config build/webpack.server.config.js --progress --hide-modules"
   },
   "engines": {
     "node": ">=7.0",
@@ -18,7 +18,7 @@
   "dependencies": {
     "babel-polyfill": "^6.26.0",
     "compression": "^1.7.1",
-    "cross-env": "^5.0.5",
+    "cross-env": "^5.1.1",
     "es6-promise": "^4.1.1",
     "express": "^4.16.2",
     "extract-text-webpack-plugin": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1473,9 +1473,9 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-env@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.0.5.tgz#4383d364d9660873dd185b398af3bfef5efffef3"
+cross-env@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.1.tgz#b6d8ab97f304c0f71dae7277b75fe424c08dfa74"
   dependencies:
     cross-spawn "^5.1.0"
     is-windows "^1.0.0"


### PR DESCRIPTION
having this error when running npm scripts
```error
'NODE_ENV' is not recognized as an internal or external command
```
and this pr will fix that issue.