### PR TITLE
fix duplicate property in Navigation Drawer docs

### DIFF
--- a/releases/0.16/pages/NavigationDrawerView.vue
+++ b/releases/0.16/pages/NavigationDrawerView.vue
@@ -64,7 +64,7 @@
                   'Sets the navigation drawer position to absolute',
                 ],
                 [
-                  'absolute',
+                  'fixed',
                   'Boolean',
                   'False',
                   'Sets the navigation drawer position to fixed',


### PR DESCRIPTION
The `fixed` property was mislabeled as `absolute`.