### PR TITLE
fix possible typo in data tables docs

### DIFF
--- a/pages/DatatablesView.vue
+++ b/pages/DatatablesView.vue
@@ -201,7 +201,7 @@
                 ],
                 [
                   'scope[items]',
-                  'The scoped slot for templating the row display. Available props are the currently iterated <code>item</code> and its <code>index</code> within the iterated items array. Provide either a <kbd>tr</kbd> tag or <kbd>th</kbd> tags for all columns.'
+                  'The scoped slot for templating the row display. Available props are the currently iterated <code>item</code> and its <code>index</code> within the iterated items array. Provide either a <kbd>tr</kbd> tag or <kbd>td</kbd> tags for all columns.'
                 ],
                 [
                   'scope[pageText]',


### PR DESCRIPTION
I'm not sure but maybe there should be `td` instead of `th` in description of items slot. Thanks anyway!