### PR TITLE
Expansion Panel: swap `popout` and `inset` descriptions

### DIFF
--- a/pages/ExpansionPanelView.vue
+++ b/pages/ExpansionPanelView.vue
@@ -37,13 +37,13 @@
                   'inset',
                   'Boolean',
                   'False',
-                  'Makes the expansion panel open with a popout style'
+                  'Makes the expansion panel open with an inset style'
                 ],
                 [
                   'popout',
                   'Boolean',
                   'False',
-                  'Makes the expansion panel open with an inset style'
+                  'Makes the expansion panel open with a popout style'
                 ]
               ]
             },


### PR DESCRIPTION
Looks like the `inset` & `popout` descriptions got switched at some point. This puts 'em back in order :)

Closes #380 