### PR TITLE
Attempt to make grid offset example more explanatory

### DIFF
--- a/examples/grid/offset.vue
+++ b/examples/grid/offset.vue
@@ -8,17 +8,17 @@
       </v-flex>
       <v-flex xs7 offset-xs0 offset-md2 offset-lg5>
         <v-card dark color="secondary">
-          <v-card-text>xs7 offset-xs5</v-card-text>
+          <v-card-text>xs7 offset-(xs5|md2|lg5)</v-card-text>
         </v-card>
       </v-flex>
       <v-flex xs12 sm5 md2>
         <v-card dark color="primary">
-          <v-card-text>xs5</v-card-text>
+          <v-card-text>(xs12|sm5|md2)</v-card-text>
         </v-card>
       </v-flex>
       <v-flex xs12 sm5 md3 offset-xs0 offset-lg2>
         <v-card dark color="green">
-          <v-card-text>xs5 offset-xs2</v-card-text>
+          <v-card-text>(xs12|sm5|md3) offset-(xs0|lg2)</v-card-text>
         </v-card>
       </v-flex>
     </v-layout>


### PR DESCRIPTION
I'm newish to the whole grid layout thing (glossed over it when I was poking at bootstrap). But I needed to understand it this time around and the offset example really confused me. One of the boxes was clearly 2 wide, but said it was xs5. I didn't understand how any of it worked until I dug through the code and saw some anomalies. This is my attempt to be a little more verbose so that the reader will have a better understanding at why the boxes are changing when the window is resized.

Ideally, things like "xs12" would only be shown on xs layouts and "sm5" would be shown on small layouts. I haven't figured out if that is possible yet or if it would even make the example far too complex. My PR is a happy compromise.
