### PR TITLE
Update vee-validate.vue

### DIFF
--- a/examples/forms/vee-validate.vue
+++ b/examples/forms/vee-validate.vue
@@ -68,7 +68,7 @@
         this.email = ''
         this.select = null
         this.checkbox = null
-        this.$validator.clean()
+        this.$validator.reset()
       }
     }
 

--- a/examples/forms/vee-validate.vue
+++ b/examples/forms/vee-validate.vue
@@ -68,7 +68,8 @@
         this.email = ''
         this.select = null
         this.checkbox = null
-        this.$validator.reset()
+        // Little hack with nextTick to avoid error being proc while reset. Probably due to timing.
+        this.$nextTick(() => this.$validator.reset())
       }
     }
 


### PR DESCRIPTION
Clean is now deprecated according to VeeValidate doc.

[vee-validate] validator.clean is marked for deprecation, please use validator.reset instead.